### PR TITLE
Optimize email logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: php
 
 php:
-    - 5.6
-    - 7.0
     - 7.1
     - 7.2
+    - 7.3
+    - 7.4
     - nightly
 
 env:

--- a/metadata/admin/charcoal/email/email-log.json
+++ b/metadata/admin/charcoal/email/email-log.json
@@ -17,9 +17,7 @@
                     "to",
                     "campaign",
                     "subject",
-                    "sendError",
-                    "messageId",
-                    "ip"
+                    "messageId"
                 ],
                 "orders": [
                     {
@@ -83,9 +81,7 @@
                             "campaign",
                             "from",
                             "to",
-                            "subject",
-                            "ip",
-                            "session_id"
+                            "subject"
                         ],
                         "layout": {
                             "structure": [
@@ -99,9 +95,7 @@
                     "status": {
                         "title": "Status",
                         "properties": [
-                            "message_id",
-                            "send_status",
-                            "send_error"
+                            "message_id"
                         ]
                     }
                 }

--- a/metadata/admin/charcoal/email/email-queue-item.json
+++ b/metadata/admin/charcoal/email/email-queue-item.json
@@ -83,9 +83,10 @@
                     "en": "Sent status"
                 },
                 "layout": {
-                    "structure": [{
-                        "columns": [1, 2]
-                    },
+                    "structure": [
+                        {
+                            "columns": [1, 2]
+                        },
                         {
                             "columns": [1]
                         },
@@ -109,9 +110,10 @@
                     "fr": "Message"
                 },
                 "layout": {
-                    "structure": [{
-                        "columns": [1, 1]
-                    },
+                    "structure": [
+                        {
+                            "columns": [1, 1]
+                        },
                         {
                             "columns": [1]
                         },

--- a/metadata/charcoal/email/email-log.json
+++ b/metadata/charcoal/email/email-log.json
@@ -3,11 +3,19 @@
         "id": {
             "type": "id"
         },
-        "type": {
-            "type": "string"
+        "queue_id": {
+            "type": "string",
+            "label": {
+                "en": "Queue Identifier",
+                "fr": "Identifiant de la queue"
+            }
         },
-        "action": {
-            "type": "string"
+        "error_code": {
+            "type": "string",
+            "label": {
+                "en": "Error code",
+                "fr": "Code d'erreur"
+            }
         },
         "message_id": {
             "type": "string",
@@ -55,39 +63,11 @@
                 "fr": "Date"
             }
         },
-        "send_status": {
-            "type": "string",
-            "label": {
-                "en": "Send Status",
-                "fr": "Status d'envoi"
-            }
-        },
-        "send_error": {
-            "type": "string",
-            "label": {
-                "en": "Send Error",
-                "fr": "Erreur d'envoi"
-            }
-        },
         "campaign": {
             "type": "string",
             "label": {
                 "en": "Campaign",
                 "fr": "Campagne"
-            }
-        },
-        "ip": {
-            "type": "ip",
-            "label": {
-                "en": "IP Address",
-                "fr": "Adresse IP"
-            }
-        },
-        "session_id": {
-            "type": "string",
-            "label": {
-                "en": "Session Identifier",
-                "fr": "Identifiant de message"
             }
         }
     },

--- a/src/Charcoal/Email/Email.php
+++ b/src/Charcoal/Email/Email.php
@@ -1022,17 +1022,17 @@ class Email implements
         foreach ($recipients as $to) {
             $log = $this->logFactory()->create('charcoal/email/email-log');
 
-            $log->setType('email');
-            $log->setAction('send');
-
+            $log->setQueueId($this->queueId());
             $log->setMessageId($mailer->getLastMessageId());
             $log->setCampaign($this->campaign());
-
             $log->setSendTs('now');
-
             $log->setFrom($mailer->From);
             $log->setTo($to);
             $log->setSubject($this->subject());
+
+            if (!empty($mailer->getSMTPInstance()->getError()['smtp_code'])) {
+                $log->setErrorCode($mailer->getSMTPInstance()->getError()['smtp_code']);
+            }
 
             $log->save();
         }

--- a/src/Charcoal/Email/EmailConfig.php
+++ b/src/Charcoal/Email/EmailConfig.php
@@ -99,13 +99,13 @@ class EmailConfig extends AbstractConfig
     public function defaults()
     {
         return [
-            'smtp'              => false,
+            'smtp'             => false,
 
-            'default_from'      => '',
-            'default_reply_to'  => '',
+            'default_from'     => '',
+            'default_reply_to' => '',
 
-            'default_track'     => false,
-            'default_log'       => true
+            'default_track'    => false,
+            'default_log'      => true
         ];
     }
 

--- a/src/Charcoal/Email/EmailLog.php
+++ b/src/Charcoal/Email/EmailLog.php
@@ -18,18 +18,18 @@ class EmailLog extends AbstractModel
     use EmailAwareTrait;
 
     /**
-     * Type of log (e.g., "email").
+     * The Queue ID
      *
-     * @var string $type
+     * @var string $queueId
      */
-    private $type;
+    private $queueId;
 
     /**
-     * The action logged (e.g., "send").
+     * The error code
      *
-     * @var string $action
+     * @var string $errorCode
      */
-    private $action;
+    private $errorCode;
 
     /**
      * The Message-ID (Unique message identifier)
@@ -67,41 +67,11 @@ class EmailLog extends AbstractModel
     private $subject;
 
     /**
-     * Whether the email has been semt.
-     *
-     * Error code (0 = success)
-     *
-     * @var integer $sendStatus
-     */
-    private $sendStatus;
-
-    /**
-     * The error message from a failed send.
-     *
-     * @var string $sendError
-     */
-    private $sendError;
-
-    /**
      * When the email should be sent.
      *
      * @var DateTimeInterface|null $sendTs
      */
     private $sendTs;
-
-    /**
-     * The current IP address at the time of the log.
-     *
-     * @var string $ip
-     */
-    private $ip;
-
-    /**
-     * The current session ID at the time of the log.
-     *
-     * @var string $sessionId
-     */
-    private $sessionId;
 
     /**
      * Get the primary key that uniquely identifies each queue item.
@@ -114,63 +84,49 @@ class EmailLog extends AbstractModel
     }
 
     /**
-     * Set the type of log.
+     * Set the queue ID.
      *
-     * @param  string $type The log type. (e.g., "email").
-     * @throws InvalidArgumentException If the log type is not a string.
+     * @param  string $queueId The queue ID.
      * @return self
      */
-    public function setType($type)
+    public function setQueueId($queueId)
     {
-        if (!is_string($type)) {
-            throw new InvalidArgumentException(
-                'Log type must be a string.'
-            );
-        }
-
-        $this->type = $type;
+        $this->queueId = $queueId;
 
         return $this;
     }
 
     /**
-     * Get the log type.
+     * Get the queue ID.
      *
      * @return string
      */
-    public function type()
+    public function queueId()
     {
-        return $this->type;
+        return $this->queueId;
     }
 
     /**
-     * Set the logged action.
+     * Set the error code.
      *
-     * @param  string $action The log action (e.g., "send").
-     * @throws InvalidArgumentException If the action is not a string.
+     * @param  string $errorCode The error code.
      * @return self
      */
-    public function setAction($action)
+    public function setErrorCode($errorCode)
     {
-        if (!is_string($action)) {
-            throw new InvalidArgumentException(
-                'Action must be a string.'
-            );
-        }
-
-        $this->action = $action;
+        $this->errorCode = $errorCode;
 
         return $this;
     }
 
     /**
-     * Get the logged action.
+     * Get the error code.
      *
      * @return string
      */
-    public function action()
+    public function errorCode()
     {
-        return $this->action;
+        return $this->errorCode;
     }
 
     /**
@@ -202,7 +158,6 @@ class EmailLog extends AbstractModel
     {
         return $this->messageId;
     }
-
 
     /**
      * Set the campaign ID.
@@ -310,42 +265,6 @@ class EmailLog extends AbstractModel
     }
 
     /**
-     * @param  string $status The mailer's status code or description.
-     * @return self
-     */
-    public function setSendStatus($status)
-    {
-        $this->sendStatus = $status;
-        return $this;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function sendStatus()
-    {
-        return $this->sendStatus;
-    }
-
-    /**
-     * @param  string $errorMessage The mailer's error code or description.
-     * @return self
-     */
-    public function setSendError($errorMessage)
-    {
-        $this->sendError = $errorMessage;
-        return $this;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function sendError()
-    {
-        return $this->sendError;
-    }
-
-    /**
      * @param  null|string|DateTime $ts The "send date" datetime value.
      * @throws InvalidArgumentException If the ts is not a valid datetime value.
      * @return self
@@ -384,54 +303,12 @@ class EmailLog extends AbstractModel
     }
 
     /**
-     * @param mixed $ip The IP adress.
-     * @return self
-     */
-    public function setIp($ip)
-    {
-        $this->ip = $ip;
-        return $this;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function ip()
-    {
-        return $this->ip;
-    }
-
-    /**
-     * @param string $sessionId The session identifier.
-     * @return self
-     */
-    public function setSessionId($sessionId)
-    {
-        $this->sessionId = $sessionId;
-        return $this;
-    }
-
-    /**
-     * @return string
-     */
-    public function sessionId()
-    {
-        return $this->sessionId;
-    }
-
-    /**
      * @see    StorableTrait::preSave()
      * @return boolean
      */
     protected function preSave()
     {
         parent::preSave();
-
-        $ip = (isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '');
-        $sessionId = session_id();
-
-        $this->setIp($ip);
-        $this->setSessionId($sessionId);
 
         if ($this->sendTs() === null) {
             $this->setSendTs('now');

--- a/src/Charcoal/Email/EmailQueueItem.php
+++ b/src/Charcoal/Email/EmailQueueItem.php
@@ -213,9 +213,9 @@ class EmailQueueItem extends AbstractModel implements QueueItemInterface
      */
     public function setMsgHtml($body)
     {
-        if (!is_string($body)) {
+        if (!is_string($body) && !is_null($body)) {
             throw new InvalidArgumentException(
-                'HTML message needs to be a string'
+                'HTML message needs to be a string or null'
             );
         }
 
@@ -243,9 +243,9 @@ class EmailQueueItem extends AbstractModel implements QueueItemInterface
      */
     public function setMsgTxt($body)
     {
-        if (!is_string($body)) {
+        if (!is_string($body) && !is_null($body)) {
             throw new InvalidArgumentException(
-                'Plan-text message needs to be a string'
+                'Plan-text message needs to be a string or null'
             );
         }
 
@@ -320,10 +320,13 @@ class EmailQueueItem extends AbstractModel implements QueueItemInterface
 
         try {
             $res = $email->send();
+
             if ($res === true) {
                 $this->setProcessed(true);
                 $this->setProcessedDate('now');
-                $this->update(['processed', 'processed_date']);
+                $this->setMsgHtml(null);
+                $this->setMsgTxt(null);
+                $this->update(['processed', 'processed_date', 'msg_html', 'msg_txt']);
 
                 if ($successCallback !== null) {
                     $successCallback($this);

--- a/src/Charcoal/Email/Script/ProcessQueueScript.php
+++ b/src/Charcoal/Email/Script/ProcessQueueScript.php
@@ -34,7 +34,7 @@ class ProcessQueueScript extends AbstractScript implements CronScriptInterface
     private $queueItemFactory;
 
     /**
-     * A copy of all sent message.
+     * A copy of all sent messages.
      *
      * @var array $sent
      */
@@ -52,12 +52,12 @@ class ProcessQueueScript extends AbstractScript implements CronScriptInterface
         // Unused parameter
         unset($request);
 
-        // Lock script, to ensure it can not be run twice  at the same time (before previous instance is done).
+        // Lock script, to ensure it can not be run twice at the same time (before previous instance is done).
         $this->startLock();
 
         $climate = $this->climate();
 
-        $processedCallback = function($success, $failures, $skipped) use ($climate) {
+        $processedCallback = function ($success, $failures, $skipped) use ($climate) {
             if (!empty($success)) {
                 $climate->green()->out(sprintf('%s emails were successfully sent.', count($success)));
             }
@@ -72,8 +72,9 @@ class ProcessQueueScript extends AbstractScript implements CronScriptInterface
         };
 
         $queueManager = new EmailQueueManager([
-            'logger' => $this->logger,
-            'queue_item_factory' => $this->queueItemFactory
+            'logger'             => $this->logger,
+            'queue_item_factory' => $this->queueItemFactory,
+            'chunkSize'          => 100
         ]);
         $queueManager->setProcessedCallback($processedCallback);
         $queueManager->processQueue();

--- a/src/Charcoal/Email/ServiceProvider/EmailServiceProvider.php
+++ b/src/Charcoal/Email/ServiceProvider/EmailServiceProvider.php
@@ -63,12 +63,12 @@ class EmailServiceProvider implements ServiceProviderInterface
                 'base_class' => EmailInterface::class,
                 'default_class' => Email::class,
                 'arguments' => [[
-                    'logger'    => $container['logger'],
-                    'config'    => $container['email/config'],
-                    'view'      => $container['email/view'],
-                    'template_factory' => $container['template/factory'],
+                    'logger'             => $container['logger'],
+                    'config'             => $container['email/config'],
+                    'view'               => $container['email/view'],
+                    'template_factory'   => $container['template/factory'],
                     'queue_item_factory' => $container['model/factory'],
-                    'log_factory' => $container['model/factory']
+                    'log_factory'        => $container['model/factory']
                 ]]
             ]);
         };

--- a/tests/Charcoal/Email/EmailLogTest.php
+++ b/tests/Charcoal/Email/EmailLogTest.php
@@ -26,33 +26,23 @@ class EmailLogTest extends PHPUnit_Framework_TestCase
     public function testSetData()
     {
         $ret = $this->obj->setData([
-            'type'         => 'email',
-            'action'       => 'foo',
+            'queue_id'     => 'foo',
             'message_id'   => 'foobar',
             'campaign'     => 'phpunit',
             'to'           => 'phpunit@example.com',
             'from'         => 'charcoal@locomotive.ca',
             'subject'      => 'Foo bar',
-            'send_status'  => 0,
-            'send_error'   => 0,
             'send_ts'      => '2010-01-02 03:45:00',
-            'ip'           => '1.2.3.4',
-            'session_id'   => 'foobar'
         ]);
         $this->assertSame($this->obj, $ret);
 
-        $this->assertEquals('email', $this->obj->type());
-        $this->assertEquals('foo', $this->obj->action());
         $this->assertEquals('foobar', $this->obj->messageId());
         $this->assertEquals('phpunit', $this->obj->campaign());
+        $this->assertEquals('foo', $this->obj->queueId());
         $this->assertEquals('phpunit@example.com', $this->obj->to());
         $this->assertEquals('charcoal@locomotive.ca', $this->obj->from());
         $this->assertEquals('Foo bar', $this->obj->subject());
-        $this->assertEquals(0, $this->obj->sendStatus());
-        $this->assertEquals(0, $this->obj->sendError());
         $this->assertEquals(new DateTime('2010-01-02 03:45:00'), $this->obj->sendTs());
-        $this->assertEquals('1.2.3.4', $this->obj->ip());
-        $this->assertEquals('foobar', $this->obj->sessionId());
     }
 
     public function testKey()


### PR DESCRIPTION
Clean up des propriétés et méthodes inutiles + clean up de code un peu + process les emails de la queue par chunk pour pas buster la mémoire lors des envoies massifs de courriels avec beaucoup de html + enlever le contenue du email de la tables après l'avoir envoyé pour ne pas avoir des bases de données trop lourdes.