### PR TITLE
Update to charcoal-queue v0.3 + Improve ProcessQueueScript

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "prefer-stable": true,
     "extra": {
         "branch-alias": {
-            "dev-master": "0.4.x-dev"
+            "dev-master": "0.5.x-dev"
         }
     },
     "require": {
@@ -24,7 +24,7 @@
         "phpmailer/phpmailer": "~6.0",
         "locomotivemtl/charcoal-config": "~0.6",
         "locomotivemtl/charcoal-app": "~0.6",
-        "locomotivemtl/charcoal-queue": "~0.2",
+        "locomotivemtl/charcoal-queue": "~0.3",
         "seld/jsonlint": "^1.7"
     },
     "require-dev": {

--- a/src/Charcoal/Email/EmailQueueItem.php
+++ b/src/Charcoal/Email/EmailQueueItem.php
@@ -29,13 +29,6 @@ class EmailQueueItem extends AbstractModel implements QueueItemInterface
     use EmailAwareTrait;
 
     /**
-     * The queue item ID.
-     *
-     * @var string|null $ident
-     */
-    private $ident;
-
-    /**
      * The recipient's email address.
      *
      * @var string $to
@@ -82,8 +75,6 @@ class EmailQueueItem extends AbstractModel implements QueueItemInterface
      */
     private $emailFactory;
 
-
-
     /**
      * Get the primary key that uniquely identifies each queue item.
      *
@@ -92,28 +83,6 @@ class EmailQueueItem extends AbstractModel implements QueueItemInterface
     public function key()
     {
         return 'id';
-    }
-
-    /**
-     * Set the queue item's ID.
-     *
-     * @param  string|null $ident The unique queue item identifier.
-     * @return self
-     */
-    public function setIdent($ident)
-    {
-        $this->ident = $ident;
-        return $this;
-    }
-
-    /**
-     * Get the queue item's ID.
-     *
-     * @return string
-     */
-    public function ident()
-    {
-        return $this->ident;
     }
 
     /**

--- a/src/Charcoal/Email/EmailQueueManager.php
+++ b/src/Charcoal/Email/EmailQueueManager.php
@@ -2,24 +2,24 @@
 
 namespace Charcoal\Email;
 
-// Dependencies from `charcoal-queue`
+// From 'charcoal-queue'
 use Charcoal\Queue\AbstractQueueManager;
 
-// Local namespace dependencies
+// From 'charcoal-email'
 use Charcoal\Email\EmailQueueItem;
 
 /**
- * Queue manager for emails.
+ * Email Queue Manager
  */
 class EmailQueueManager extends AbstractQueueManager
 {
     /**
-     * Retrieve the queue item's model.
+     * Retrieve the class name of the queue item model.
      *
-     * @return EmailQueueItem
+     * @return string
      */
-    public function queueItemProto() : EmailQueueItem
+    public function getQueueItemClass(): string
     {
-        return $this->queueItemFactory()->create(EmailQueueItem::class);
+        return EmailQueueItem::class;
     }
 }

--- a/src/Charcoal/Email/Script/ProcessQueueScript.php
+++ b/src/Charcoal/Email/Script/ProcessQueueScript.php
@@ -4,26 +4,26 @@ declare(strict_types=1);
 
 namespace Charcoal\Email\Script;
 
-// From 'psr/http-message' (PSR-7)
+// From PSR-7
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
-// From 'pimple/pimple'
+// From Pimple
 use Pimple\Container;
 
-// From 'locomotivemtl/charcoal-app'
+// From 'charcoal-app'
 use Charcoal\App\Script\AbstractScript;
 use Charcoal\App\Script\CronScriptInterface;
 use Charcoal\App\Script\CronScriptTrait;
 
-// From 'locomotivemtl/charcoal-factory'
+// From 'charcoal-factory'
 use Charcoal\Factory\FactoryInterface;
 
-// Local dependencies
+// From 'charcoal-email'
 use Charcoal\Email\EmailQueueManager;
 
 /**
- * Process Email Queue script.
+ * Script: Process Email Queue
  *
  * Can also be used as a cron script.
  */
@@ -32,16 +32,9 @@ class ProcessQueueScript extends AbstractScript implements CronScriptInterface
     use CronScriptTrait;
 
     /**
-     * @var FactoryInterface $queueItemFactory
+     * @var FactoryInterface
      */
     private $queueItemFactory;
-
-    /**
-     * A copy of all sent messages.
-     *
-     * @var array $sent
-     */
-    private $sent;
 
     /**
      * Process all messages currently in queue.
@@ -55,18 +48,131 @@ class ProcessQueueScript extends AbstractScript implements CronScriptInterface
         // Unused parameter
         unset($request);
 
-        // Lock script, to ensure it can not be run twice at the same time (before previous instance is done).
+        // Lock script; Ensure it can not be run twice at the same time.
         $this->startLock();
 
+        $cli = $this->climate();
+
+        if ($this->dryRun()) {
+            $cli->shout('This command does not support --dry-run');
+            $cli->br();
+            $cli->whisper('Doing nothing');
+            return $response;
+        }
+
+        $queueManager = $this->makeQueueManager();
+        $queueManager->processQueue();
+
+        // Unlock script
+        $this->stopLock();
+
+        return $response;
+    }
+
+    /**
+     * Default script arguments.
+     *
+     * @return array
+     */
+    public function defaultArguments()
+    {
+        $arguments = [
+            'queue-id' => [
+                'longPrefix'   => 'queue-id',
+                'description'  => 'The queue to process. If blank, all queues will be processed.',
+                'defaultValue' => null,
+                'castTo'       => 'string',
+            ],
+            'rate' => [
+                'longPrefix'   => 'rate',
+                'description'  => 'Number of items to process per second.',
+                'defaultValue' => 50,
+                'castTo'       => 'int',
+            ],
+            'limit' => [
+                'longPrefix'   => 'limit',
+                'description'  => 'Maximum number of items to process.',
+                'defaultValue' => null,
+                'castTo'       => 'int',
+            ],
+            'chunk-size' => [
+                'longPrefix'   => 'chunk-size',
+                'description'  => 'Number of items to keep in memory at a given time.',
+                'defaultValue' => 100,
+                'castTo'       => 'int',
+            ],
+        ];
+
+        $arguments = array_merge(parent::defaultArguments(), $arguments);
+        return $arguments;
+    }
+
+    /**
+     * Create and prepare the queue manager.
+     *
+     * @return EmailQueueManager
+     */
+    protected function makeQueueManager()
+    {
+        $cli = $this->climate();
+
+        $data = [
+            'logger'             => $this->logger,
+            'queue_item_factory' => $this->queueItemFactory,
+            'chunkSize'          => 100,
+        ];
+
+        $rate = $cli->arguments->get('rate');
+        if ($rate !== null) {
+            $data['rate'] = $rate;
+        }
+
+        $limit = $cli->arguments->get('limit');
+        if ($limit !== null) {
+            $data['limit'] = $limit;
+        }
+
+        $chunkSize = $cli->arguments->get('chunk-size');
+        if ($chunkSize !== null) {
+            $data['chunkSize'] = $chunkSize;
+        }
+
+        $class = $this->getQueueManagerClass();
+        $queueManager = new $class($data);
+        $queueManager->setProcessedCallback($this->getProcessedQueueCallback());
+
+        $queueId = $cli->arguments->get('queue-id');
+        if ($queueId !== null) {
+            $data['queue_id'] = $queueId;
+        }
+
+        return $queueManager;
+    }
+
+    /**
+     * Retrieve the class name of the queue manager model.
+     *
+     * @return string
+     */
+    protected function getQueueManagerClass(): string
+    {
+        return EmailQueueManager::class;
+    }
+
+    /**
+     * @return Closure
+     */
+    protected function getProcessedQueueCallback(): callable
+    {
         $climate = $this->climate();
 
-        $processedCallback = function ($success, $failures, $skipped) use ($climate): void {
+        $callback = function ($success, $failures, $skipped) use ($climate): void {
             if (!empty($success)) {
                 $climate->green()->out(sprintf('%s emails were successfully sent.', count($success)));
             }
 
             if (!empty($failures)) {
-                $climate->red()->out(sprintf('%s emails were not successfully sent', count($failures)));
+                $climate->red()->out(sprintf('%s emails failed to be sent', count($failures)));
             }
 
             if (!empty($skipped)) {
@@ -74,21 +180,11 @@ class ProcessQueueScript extends AbstractScript implements CronScriptInterface
             }
         };
 
-        $queueManager = new EmailQueueManager([
-            'logger'             => $this->logger,
-            'queue_item_factory' => $this->queueItemFactory,
-            'chunkSize'          => 100
-        ]);
-        $queueManager->setProcessedCallback($processedCallback);
-        $queueManager->processQueue();
-
-        $this->stopLock();
-
-        return $response;
+        return $callback;
     }
 
     /**
-     * @param Container $container Pimple DI container.
+     * @param  Container $container Pimple DI container.
      * @return void
      */
     protected function setDependencies(Container $container): void
@@ -98,7 +194,7 @@ class ProcessQueueScript extends AbstractScript implements CronScriptInterface
     }
 
     /**
-     * @param FactoryInterface $factory The factory to create queue items.
+     * @param  FactoryInterface $factory The factory to create queue items.
      * @return void
      */
     private function setQueueItemFactory(FactoryInterface $factory): void

--- a/tests/Charcoal/Email/EmailQueueItemTest.php
+++ b/tests/Charcoal/Email/EmailQueueItemTest.php
@@ -41,6 +41,6 @@ class EmailQueueItemTest extends AbstractTestCase
      */
     public function testConstructor()
     {
-        $this->assertInstanceOf(EmailQueueItem::class, $this->obj);
+        $this->assertInstanceOf(QueueItemInterface::class, $this->obj);
     }
 }

--- a/tests/Charcoal/Email/EmailQueueItemTest.php
+++ b/tests/Charcoal/Email/EmailQueueItemTest.php
@@ -14,20 +14,33 @@ class EmailQueueItemTest extends AbstractTestCase
      */
     public $obj;
 
+    /**
+     * Set up the test.
+     *
+     * @return void
+     */
     public function setUp()
     {
-        $this->obj = new EmailQueueItem([
+        $this->obj = $this->createObj();
+    }
+
+    /**
+     * Create tested class.
+     *
+     * @return EmailQueueItem
+     */
+    public function createObj()
+    {
+        return new EmailQueueItem([
             'logger' => new NullLogger()
         ]);
     }
 
-    public function testSetData()
+    /**
+     * @return void
+     */
+    public function testConstructor()
     {
-        $ret = $this->obj->setData([
-            'ident' => 'phpunit'
-        ]);
-        $this->assertSame($this->obj, $ret);
-
-        $this->assertEquals('phpunit', $this->obj->ident());
+        $this->assertInstanceOf(EmailQueueItem::class, $this->obj);
     }
 }


### PR DESCRIPTION
Requires:

- locomotivemtl/charcoal-queue#2

Breaking:

- Queue Managers: Replace method `queueItemProto()` with `queueItemClass()`.
- Queue Items: Rename first argument in `process()` to clarify usage.

Changed:

- Refactored `ProcessQueueScript` controller to support CLI arguments to customize queue managers: `queue-id`, `chunk-size`, `limit`, `rate`.  
  Default arguments: `rate: 50`, `chunk-size: 100`