### PR TITLE
Parser Service

### DIFF
--- a/src/Charcoal/Email/ServiceProvider/EmailServiceProvider.php
+++ b/src/Charcoal/Email/ServiceProvider/EmailServiceProvider.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Charcoal\Email\ServiceProvider;
 
 // From 'pimple/pimple'
-use Charcoal\Factory\FactoryInterface;
 use Charcoal\View\ViewInterface;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
@@ -13,12 +12,14 @@ use Pimple\ServiceProviderInterface;
 // From 'phpmailer/phpmailer'
 use PHPMailer\PHPMailer\PHPMailer;
 
-// From 'charcoal-factory'
+// From 'locomotivemtl/charcoal-factory'
+use Charcoal\Factory\FactoryInterface;
 use Charcoal\Factory\GenericFactory;
 
 use Charcoal\Email\Email;
 use Charcoal\Email\EmailInterface;
 use Charcoal\Email\EmailConfig;
+use Charcoal\Email\Services\Parser;
 
 /**
  * Email Service Provider
@@ -57,6 +58,7 @@ class EmailServiceProvider implements ServiceProviderInterface
         };
 
         /**
+         * @param Container $container Pimple DI Container.
          * @return FactoryInterface
          */
         $container['email/factory'] = function(Container $container): FactoryInterface {
@@ -75,6 +77,13 @@ class EmailServiceProvider implements ServiceProviderInterface
                     'log_factory'        => $container['model/factory']
                 ]]
             ]);
+        };
+
+        /**
+         * @return Parser
+         */
+        $container['email/parser'] = function(): Parser {
+            return new Parser();
         };
 
         /**

--- a/src/Charcoal/Email/Services/Parser.php
+++ b/src/Charcoal/Email/Services/Parser.php
@@ -12,7 +12,12 @@ use InvalidArgumentException;
 class Parser
 {
     /**
-     * @param mixed $email An email value (either a string or an array).
+     * @var string
+     */
+    public const REGEXP = '/(.+[\s]+)?(<)?(([\w\-\._\+]+)@((?:[\w\-_]+\.)+)([a-zA-Z]*))?(>)?/u';
+
+    /**
+     * @param string|array $email An email value (either a string or an array).
      * @throws InvalidArgumentException If the email is invalid.
      * @return string
      */
@@ -33,14 +38,13 @@ class Parser
     /**
      * Convert an email address (RFC822) into a proper array notation.
      *
-     * @param  string|array $var An email array (containing an "email" key and optionally a "name" key).
+     * @param  string $var An email array (containing an "email" key and optionally a "name" key).
      * @throws InvalidArgumentException If the email is invalid.
      * @return array
      */
     public function emailToArray(string $var) : array
     {
-        $regexp = '/(.+[\s]+)?(<)?(([\w\-\._\+]+)@((?:[\w\-_]+\.)+)([a-zA-Z]*))?(>)?/u';
-        preg_match($regexp, $var, $out);
+        preg_match(self::REGEXP, $var, $out);
         return [
             'email' => (isset($out[3]) ? trim($out[3]) : ''),
             'name'  => (isset($out[1]) ? trim(trim($out[1]), '\'"') : '')

--- a/src/Charcoal/Email/Services/Parser.php
+++ b/src/Charcoal/Email/Services/Parser.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Charcoal\Email\Services;
+
+use InvalidArgumentException;
+
+/**
+ * Parser service
+ */
+class Parser
+{
+    /**
+     * @param mixed $email An email value (either a string or an array).
+     * @throws InvalidArgumentException If the email is invalid.
+     * @return string
+     */
+    public function parse($email): string
+    {
+        if (is_array($email)) {
+            return $this->emailFromArray($email);
+        } elseif (is_string($email)) {
+            $arr = $this->emailToArray($email);
+            return $this->emailFromArray($arr);
+        } else {
+            throw new InvalidArgumentException(
+                'Can not parse email: must be an array or a string'
+            );
+        }
+    }
+
+    /**
+     * Convert an email address (RFC822) into a proper array notation.
+     *
+     * @param  string|array $var An email array (containing an "email" key and optionally a "name" key).
+     * @throws InvalidArgumentException If the email is invalid.
+     * @return array
+     */
+    public function emailToArray(string $var) : array
+    {
+        $regexp = '/(.+[\s]+)?(<)?(([\w\-\._\+]+)@((?:[\w\-_]+\.)+)([a-zA-Z]*))?(>)?/u';
+        preg_match($regexp, $var, $out);
+        return [
+            'email' => (isset($out[3]) ? trim($out[3]) : ''),
+            'name'  => (isset($out[1]) ? trim(trim($out[1]), '\'"') : '')
+        ];
+    }
+
+    /**
+     * Convert an email address array to a RFC-822 string notation.
+     *
+     * @param  array $arr An email array (containing an "email" key and optionally a "name" key).
+     * @throws InvalidArgumentException If the email array is invalid.
+     * @return string
+     */
+    public function emailFromArray(array $arr) : string
+    {
+        if (!isset($arr['email'])) {
+            throw new InvalidArgumentException(
+                'The array must contain at least the "email" key.'
+            );
+        }
+
+        $email = strval(filter_var($arr['email'], FILTER_SANITIZE_EMAIL));
+
+        if (!isset($arr['name']) || $arr['name'] === '') {
+            return $email;
+        }
+
+        $name = str_replace('"', '', filter_var($arr['name'], FILTER_SANITIZE_STRING));
+        return sprintf('"%s" <%s>', $name, $email);
+    }
+}


### PR DESCRIPTION
Use a Parser service to parse an email (from and to a string or an array).

This service may be used in the future in all places where parsing is required and to deprecate EmailAwareTrait.